### PR TITLE
Fix a test that was failing when executed in different timezone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 lib-cov
+coverage
 *.seed
 *.log
 *.csv

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "bin": "./bin/xlsxe.js",
   "main": "./lib",
   "scripts": {
+    "cover": "istanbul cover _mocha",
     "test": "mocha"
   },
   "license": "MIT",
@@ -43,6 +44,7 @@
     "unzip2": "^0.2.5"
   },
   "devDependencies": {
+    "istanbul": "^0.4.5",
     "mocha": "*"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   ],
   "bin": "./bin/xlsxe.js",
   "main": "./lib",
+  "scripts": {
+    "test": "mocha"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/test/tests.js
+++ b/test/tests.js
@@ -156,7 +156,7 @@ describe('xlsx', function () {
 				null,
 				null,
 				'aha',
-				1296428400000,
+				(new Date(2011,0,31)).valueOf(),
 				'00002222',
 				5.94202898550725,
 				5.94,


### PR DESCRIPTION
Fix a test that was failing when executed in different timezone

The test 'should read and format all cell values' was failing when tests
are executed in different timezones.
```
  TZ=UTC-2 mocha
  TZ=UTC+5 mocha
```
I've also added cover and test npm scripts

To generate the code coverage report run `npm run cover` and open `./coverage/lcov-report/index.html` and to execute the test suit run `npm test`