### PR TITLE
Add option to stop rounding floats on extract

### DIFF
--- a/lib/xlsx-extract.js
+++ b/lib/xlsx-extract.js
@@ -293,7 +293,11 @@ Cell.prototype.applyNumFormat = function (options) {
 				break;
 			case 'f':
 				if ((usefmt.digits > 0) && options.convert_values.floats) {
-					var v = parseFloat(this.val.toFixed(usefmt.digits));
+                    if (options.round_floats) {
+                        this.val = this.val.toFixed(usefmt.digits)
+                    }
+
+					var v = parseFloat(this.val);
 					if (!isNaN(v)) {
 						this.val = v;
 					}
@@ -468,6 +472,7 @@ function XLSXReader(filename, options) {
 		tsv_delimiter: '\t',
 		format: 'array',
 		raw_values: false,
+		round_floats: true,
 		convert_values: {
 			ints: true,
 			floats: true,


### PR DESCRIPTION
For file imports using currencies with large amount of decimal digits (or even very precise excel sheets) we don't want to round float values at all despite the formatting. I have proposed a 'round_floats' option to be passed into the extraction in order to add this functionality.